### PR TITLE
feat: implement wpcs phpcs rules

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="themer Rules">
-	<rule ref="./vendor/bigbite/phpcs-config" />
+	<exclude-pattern>.git/*</exclude-pattern>
+	<exclude-pattern>build/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>node_modules/*</exclude-pattern>
+	<rule ref="WordPress" />
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
       "automattic/jetpack-autoloader": "^2.10.1"
     },
     "require-dev": {
-      "bigbite/phpcs-config": "dev-main"
+      "dealerdirect/phpcodesniffer-composer-installer": "0.7.2",
+      "wp-coding-standards/wpcs": "2.3.0"
     },
     "autoload": {
       "files": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "99b21b011ba3ec171802be6fd899d5b6",
+    "content-hash": "9e43ff94babf66ff9a184c3a53dce16a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -67,154 +67,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "automattic/vipwpcs",
-            "version": "2.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
-                "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
-                "wp-coding-standards/wpcs": "^2.3"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
-                "phpcompatibility/php-compatibility": "^9",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
-                "source": "https://github.com/Automattic/VIP-Coding-Standards",
-                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
-            },
-            "time": "2021-09-29T16:20:23+00:00"
-        },
-        {
-            "name": "bigbite/phpcs-config",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bigbite/phpcs-config.git",
-                "reference": "dae714808c15be748021e8e734948a7804cd89ca"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bigbite/phpcs-config/zipball/dae714808c15be748021e8e734948a7804cd89ca",
-                "reference": "dae714808c15be748021e8e734948a7804cd89ca",
-                "shasum": ""
-            },
-            "require": {
-                "automattic/vipwpcs": "^2.3.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-                "php": ">=7.2",
-                "squizlabs/php_codesniffer": "^3.6.2",
-                "wp-coding-standards/wpcs": "^2.3.0"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcompatibility/php-compatibility": "^9.3.5",
-                "phpcsstandards/phpcsdevtools": "^1.1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpunit/phpunit": "^7.5.20"
-            },
-            "default-branch": true,
-            "type": "phpcodesniffer-standard",
-            "archive": {
-                "exclude": [
-                    "/.editorconfig",
-                    "/.gitignore",
-                    "/.phpcs.xml.dist",
-                    "/Tests",
-                    "/phpunit.xml.dist"
-                ]
-            },
-            "scripts": {
-                "lint": [
-                    "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
-                ],
-                "phpcs": [
-                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs ."
-                ],
-                "test": [
-                    "@php ./vendor/bin/phpunit --filter BigBite ./vendor/squizlabs/php_codesniffer/tests/AllTests.php"
-                ],
-                "analyse": [
-                    "./vendor/bin/phpstan"
-                ],
-                "is-complete": [
-                    "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness -q ./BigBite"
-                ],
-                "is-complete-strict": [
-                    "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./BigBite"
-                ],
-                "install-cs": [
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
-                ],
-                "all-checks": [
-                    "@lint",
-                    "@phpcs",
-                    "@is-complete",
-                    "@test",
-                    "@analyse"
-                ],
-                "all-checks-strict": [
-                    "@lint",
-                    "@phpcs",
-                    "@is-complete-strict",
-                    "@test",
-                    "@analyse"
-                ]
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paul Taylor",
-                    "email": "paul@bigbite.net"
-                },
-                {
-                    "name": "Jon McPartland",
-                    "email": "jon@bigbite.net"
-                }
-            ],
-            "description": "Big Bite's PHP Coding Standards.",
-            "support": {
-                "source": "https://github.com/bigbite/phpcs-config/tree/main",
-                "issues": "https://github.com/bigbite/phpcs-config/issues"
-            },
-            "time": "2023-06-15T09:17:47+00:00"
-        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.2",
@@ -289,64 +141,6 @@
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
             "time": "2022-02-04T12:51:07+00:00"
-        },
-        {
-            "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.16",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": "^3.5.6"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
-                "phpcsstandards/phpcsdevcs": "^1.1",
-                "phpstan/phpstan": "^1.7",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
-                "sirbrillig/phpcs-import-detection": "^1.1",
-                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
-            },
-            "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "VariableAnalysis\\": "VariableAnalysis/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sam Graham",
-                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
-                },
-                {
-                    "name": "Payton Swick",
-                    "email": "payton@foolord.com"
-                }
-            ],
-            "description": "A PHPCS sniff to detect problems with variables.",
-            "keywords": [
-                "phpcs",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
-                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
-                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
-            },
-            "time": "2023-03-31T16:46:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -459,12 +253,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "bigbite/phpcs-config": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
## Description

Fixes [BBT-20](https://b5ecom.atlassian.net/browse/BBT-20)

Sets up the project to use version `2.3.0` of the WordPress Coding Standards.

## Tests

1. In your terminal within the `themer` plugin directory run `composer update`
2. Within the same directory run `./vendor/bin/phpcs ./`
3. `phpcs` scan output should be shown

## Change Log

- Removes bigbite phpcs-config package and ruleset
- Adds wpcs v2.3.0 package and ruleset

[BBT-20]: https://b5ecom.atlassian.net/browse/BBT-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ