### PR TITLE
[BBT-54] Updates registered menu capability check

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -22,7 +22,7 @@ class AdminSetup {
 		add_options_page(
 			__( 'Theme Settings' ),
 			'Theme Customiser',
-			'manage_options',
+			'edit_theme_options',
 			'theme_settings',
 			[ $this, 'theme_render_settings' ],
 		);


### PR DESCRIPTION
## Description

Fixes: [BBT-54](https://b5ecom.atlassian.net/browse/BBT-54)

Updates the user capability used when adding the menu item for the `Themer` plugin.


## Change Log

- Changes user capability used when registering the admin page from `manage_options` to `edit_theme_options`

## Steps to test

1. Login as an **Admin** or **Super Admin**
2. The menu item of `Settings` > `Theme Customiser` should be visible
3. Click the above menu link, the **Themer** plugin should load
4. Log out
5. Login as a user with the role **Editor**
6. Confirm that `Settings` > `Theme Customiser` isn't visible
7.  Attempt to visit `*/wp-admin/options-general.php?page=theme_settings`
8. The `Sorry, you are not allowed to access this page.` message should be displayed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[BBT-54]: https://b5ecom.atlassian.net/browse/BBT-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ