### PR TITLE
[BBT-95] Repo name incorrect in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When installing to your site, add the following to you `composer.json` file. Thi
     }
   ],
   "require": {
-    "@big-bite/themer": "dev-main-built"
+    "bigbite/themer": "dev-main-built"
   },
   "extra": {
     "installer-paths": {


### PR DESCRIPTION
## Description

[BBT-95](https://b5ecom.atlassian.net/browse/BBT-95) - This repo name was incorrect in the README meaning the setup instructions can't be followed. I've changed it to the correct repo name.

## Change Log
- Repo name corrected in README.

## Steps to test

- Check the readme for correct repo name.
- Attempt to clone using instructions.
- Attempt to pull down plugin using composer.

## Screenshots/Videos

Terminal output when using current instructions:
https://app.warp.dev/block/gF0lk1uYWayMnwLm7iPqNZ

Terminal output when using new instructions:
https://app.warp.dev/block/hKDS9qrSQrsJAntQmeCCV5

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[BBT-95]: https://b5ecom.atlassian.net/browse/BBT-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ