### PR TITLE
[BBT-97] Isolate scripts and styles to the Styles Editor page

### DIFF
--- a/inc/class-loader.php
+++ b/inc/class-loader.php
@@ -28,6 +28,11 @@ class Loader {
 	 * @return void
 	 */
 	public function enqueue_themer_assets() : void {
+		$current_screen = get_current_screen();
+		if ( 'appearance_page_styles_editor' !== $current_screen->id ) {
+			return;
+		}
+
 		$plugin_name = basename( THEMER_DIR );
 		$asset_file  = include THEMER_DIR . '/build/index.asset.php';
 


### PR DESCRIPTION
## Description

Fixes [BBT-97](https://b5ecom.atlassian.net/browse/BBT-97) - Isolates the enqueuing of the scripts and styles to just the Styles Editor by checking the current page id is `appearance_page_styles_editor`

## Change Log
- Adds a check to the `enqueue_themer_assets` method in the `Loader` class for the admin page id to make sure you are on the `appearance_page_styles_editor` (Styles Editor) page.

## Steps to test
- Check assets are only loading in on the Styles Editor page and no issues occur.

## Screenshots/Videos
No **JS** issues.
![Screenshot 2023-08-25 at 17 17 20](https://github.com/bigbite/themer/assets/5260744/f7811f36-e86d-4c40-a194-7b9340d978a0)

No **CSS** issues.
![Screenshot 2023-08-25 at 17 18 13](https://github.com/bigbite/themer/assets/5260744/70345606-4001-4116-9a35-562315b4d6f3)

Assets still load on correct page.
![Screenshot 2023-08-25 at 17 18 56](https://github.com/bigbite/themer/assets/5260744/509b9bd4-a9c2-40c8-bec3-50a567f75f9b)

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[BBT-97]: https://b5ecom.atlassian.net/browse/BBT-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ