### PR TITLE
[BBT-109] Conditionally render summary content

### DIFF
--- a/src/editor/components/BlocksItem.js
+++ b/src/editor/components/BlocksItem.js
@@ -1,3 +1,5 @@
+import { useState } from '@wordpress/element';
+
 import Border from './StylesBorder';
 import Color from './StylesColor';
 import Filter from './StylesFilter';
@@ -5,6 +7,7 @@ import Spacing from './StylesSpacing';
 import Dimensions from './StylesDimensions';
 import Outline from './StylesOutline';
 import Shadow from './StylesShadow';
+
 import getThemeOption from '../../utils/get-theme-option';
 
 /**
@@ -15,6 +18,7 @@ import getThemeOption from '../../utils/get-theme-option';
  * @param {Object} props.themeConfig Theme JSON
  */
 const BlocksItem = ( { block, themeConfig } ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
 	if ( ! block ) {
 		return;
 	}
@@ -50,47 +54,65 @@ const BlocksItem = ( { block, themeConfig } ) => {
 	);
 
 	return (
-		<details className="themer--blocks-item-component">
+		<details
+			className="themer--blocks-item-component"
+			open={ isOpen }
+			onToggle={ () => setIsOpen( ! isOpen ) }
+		>
 			<summary>{ block }</summary>
-			<div className="themer--blocks-item-component--styles">
-				{ hasBorderStyles && (
-					<Border
-						selector={ [ ...blockSelector, 'border' ].join( '.' ) }
-					/>
-				) }
-				{ hasColorStyles && (
-					<Color
-						selector={ [ ...blockSelector, 'color' ].join( '.' ) }
-					/>
-				) }
-				{ hasFilterStyles && (
-					<Filter
-						selector={ [ ...blockSelector, 'filter' ].join( '.' ) }
-					/>
-				) }
-				{ hasSpacingStyles && (
-					<Spacing
-						selector={ [ ...blockSelector, 'spacing' ].join( '.' ) }
-					/>
-				) }
-				{ hasDimensionsStyles && (
-					<Dimensions
-						selector={ [ ...blockSelector, 'dimensions' ].join(
-							'.'
-						) }
-					/>
-				) }
-				{ hasOutlineStyles && (
-					<Outline
-						selector={ [ ...blockSelector, 'outline' ].join( '.' ) }
-					/>
-				) }
-				{ hasShadowStyles && (
-					<Shadow
-						selector={ [ ...blockSelector, 'shadow' ].join( '.' ) }
-					/>
-				) }
-			</div>
+			{ isOpen && (
+				<div className="themer--blocks-item-component--styles">
+					{ hasBorderStyles && (
+						<Border
+							selector={ [ ...blockSelector, 'border' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasColorStyles && (
+						<Color
+							selector={ [ ...blockSelector, 'color' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasFilterStyles && (
+						<Filter
+							selector={ [ ...blockSelector, 'filter' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasSpacingStyles && (
+						<Spacing
+							selector={ [ ...blockSelector, 'spacing' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasDimensionsStyles && (
+						<Dimensions
+							selector={ [ ...blockSelector, 'dimensions' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasOutlineStyles && (
+						<Outline
+							selector={ [ ...blockSelector, 'outline' ].join(
+								'.'
+							) }
+						/>
+					) }
+					{ hasShadowStyles && (
+						<Shadow
+							selector={ [ ...blockSelector, 'shadow' ].join(
+								'.'
+							) }
+						/>
+					) }
+				</div>
+			) }
 		</details>
 	);
 };


### PR DESCRIPTION
## Description

This PR adds conditional rendering to the native `<summary>` HTML component which is being used to render block styles UI elements.

Fixes [BBT-109](https://b5ecom.atlassian.net/browse/BBT-109)

When using an uncontrolled HTML summary element, React will render all child content whether or not it is visible to the user. When a significant number of components are added to the tree (which is the case if we render style UI for every possible element within every block), performance will drop significantly.

To fix this, we can convert the summary element to be controlled by React, keeping it's open value in state and conditionally rendering it's content based on whether or not it is open.

## Change Log
- Convert HTML summary to a controlled element

## Steps to test

This bug was discovered when experimenting with rendering nested element styles UI within blocks, which results in almost 2000 components being rendered at once. To partially replicate this performance impact, we can copy/paste the styles components within `BlocksItem` several times. The more components present, the worse the performance will become. Then:
- Click the 'blocks' tab
- Notice a delay in rendering
- Click the search field and begin searching for a block
- Notice further delays and lag

## Screenshots/Videos

Before - http://bigbite.im/v/EQ8KRW
After - http://bigbite.im/v/NE1E0n

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[BBT-109]: https://b5ecom.atlassian.net/browse/BBT-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ