### PR TITLE
[BBT-110] Remove string handling in spacing styles component

### DIFF
--- a/src/editor/components/StylesSpacing.js
+++ b/src/editor/components/StylesSpacing.js
@@ -82,14 +82,6 @@ const Spacing = ( { selector } ) => {
 		themeConfig
 	)?.theme;
 
-	// TODO: support shorthand CSS values in theme.json
-	if (
-		typeof spacingStyles.padding === 'string' ||
-		typeof spacingStyles.margin === 'string'
-	) {
-		return null;
-	}
-
 	/**
 	 * Updates the theme config with the new value.
 	 *


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description

This PR removes the TODO and string handling from the spacing style component.

Related BBT-110

This was added after encountering an issue relating to style values being present in the theme.json as strings rather than objects with `top`, `right`, `bottom` and `left`.

However I have been unable to replicate the cause of the original issue, and we have confirmed that a string value will be classed as invalid in the schema definition, so I am opting to remove the failsafe handling as well as the todo comment.

## Steps to test

N/A
