### PR TITLE
[BBT-94] Fix: Re-add typography styles component

### DIFF
--- a/src/editor/components/Styles.js
+++ b/src/editor/components/Styles.js
@@ -2,6 +2,7 @@ import { useContext } from '@wordpress/element';
 
 import Border from './StylesBorder';
 import Color from './StylesColor';
+import Typography from './StylesTypography';
 import Filter from './StylesFilter';
 import Spacing from './StylesSpacing';
 import Dimensions from './StylesDimensions';
@@ -31,6 +32,10 @@ const Styles = ( { path } ) => {
 
 	const hasBorderStyles = getThemeOption( `${ path }.border`, themeConfig );
 	const hasColorStyles = getThemeOption( `${ path }.color`, themeConfig );
+	const hasTypographyStyles = getThemeOption(
+		`${ path }.typography`,
+		themeConfig
+	);
 	const hasFilterStyles = getThemeOption( `${ path }.filter`, themeConfig );
 	const hasSpacingStyles = getThemeOption( `${ path }.spacing`, themeConfig );
 	const hasDimensionsStyles = getThemeOption(
@@ -47,6 +52,9 @@ const Styles = ( { path } ) => {
 					<Border selector={ `${ path }.border` } />
 				) }
 				{ hasColorStyles && <Color selector={ `${ path }.color` } /> }
+				{ hasTypographyStyles && (
+					<Typography selector={ `${ path }.typography` } />
+				) }
 				{ hasFilterStyles && (
 					<Filter selector={ `${ path }.filter` } />
 				) }


### PR DESCRIPTION
## Description

Fixes [BBT-94](https://b5ecom.atlassian.net/browse/BBT-94) - During the refactor in #34 we missed importing the `typography` styles component alongside the other style components. This PR adds it back in.

## Change Log
- Re-add the typography styles component

## Steps to test
- Load the plugin with TT3 active
- Notice the typography section in the site styles tab

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[BBT-94]: https://b5ecom.atlassian.net/browse/BBT-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ