### PR TITLE
Revert "[BBT-110] Remove string handling in spacing styles component"

### DIFF
--- a/src/editor/components/StylesSpacing.js
+++ b/src/editor/components/StylesSpacing.js
@@ -82,6 +82,14 @@ const Spacing = ( { selector } ) => {
 		themeConfig
 	)?.theme;
 
+	// TODO: support shorthand CSS values in theme.json
+	if (
+		typeof spacingStyles.padding === 'string' ||
+		typeof spacingStyles.margin === 'string'
+	) {
+		return null;
+	}
+
 	/**
 	 * Updates the theme config with the new value.
 	 *


### PR DESCRIPTION
Reverts bigbite/themer#38

More back and forth on this one - once the fix was removed I seem to have hit this issue again.

It appears to be coming from the button element styles on my install. They are defined as follows in the TT3 theme:
```json
"spacing": {
	"padding": {
		"top": "min(1rem, 3vw) !important",
		"right": "min(2.75rem, 6vw) !important",
		"bottom": "min(1rem, 3vw) !important",
		"left": "min(2.75rem, 6vw) !important"
	}
}
```
However they are showing up in the application as:
```js
{padding: 'calc(0.667em + 2px) calc(1.333em + 2px)'}
```
Unsure how/when the styles are implemented, but I have confirmed they are present in the base config pulled from `__experimentalGetCurrentThemeBaseGlobalStyles`. Using WordPress 6.4.

Reverting this to add the safeguard back in for now until we can investigate a proper fix.