### PR TITLE
[BBT-119] Hide core admin notices

### DIFF
--- a/src/editor/styles/base.scss
+++ b/src/editor/styles/base.scss
@@ -6,6 +6,13 @@
 	padding-bottom: 0;
 }
 
+/**
+ * Hide core WordPress notices.
+ */
+#wpbody-content > .notice {
+	display: none;
+}
+
 #wpfooter {
 	display: none;
 }


### PR DESCRIPTION
## Description

[BBT-119](https://b5ecom.atlassian.net/browse/BBT-119) - This PR hides all core WordPress notices from the plugin pages, to prevent them from breaking the layout.

This is achieved using CSS, which should be a reliable approach in this case, however by hiding the notices we are committing to understanding that we won't be able to utilise this type of notice for our own purposes within the plugin.

## Change Log
Hides all core notices from plugin pages

## Steps to test
- Install the plugin on a site using an outdated WordPress version
- Confirm the update notice is shown on other admin pages
- Confirm the update notice is not shown on pages created by this plugin

## Screenshots/Videos

Before:
<img width="1725" alt="image" src="https://github.com/bigbite/themer/assets/41474928/dc2894ad-af3b-4f77-9113-c60096fa9cac">

After:
<img width="1728" alt="image" src="https://github.com/bigbite/themer/assets/41474928/fa089523-4433-49f8-ae36-a52d6b05e707">

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[BBT-119]: https://b5ecom.atlassian.net/browse/BBT-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ