### PR TITLE
[BBT-96] Update plugin metadata

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,15 +1,16 @@
 <?php
 /**
- * Plugin Name:       themer
- * Description:
- * Version:           1.0.0-alpha.1
- * Requires at least: 5.5
- * Requires PHP:      7.4
+ * Plugin Name:       Themer
+ * Description:       A plugin to help you style themes faster.
+ * Version:           1.0.0-alpha
+ * Requires at least: 6.2
+ * Requires PHP:      8.0
  * Author:            Big Bite
+ * Author URI:        https://bigbite.net
+ * Plugin URI:        https://github.com/bigbite/themer/
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Update URI:        https://example.com/my-plugin/
- * Text Domain:
+ * Update URI:        https://github.com/bigbite/themer/releases/
  *
  * @package themer
  */


### PR DESCRIPTION
## Description

Fixes [BBT-96](https://b5ecom.atlassian.net/browse/BBT-96) - Updates plugin metadata to correct WordPress/PHP versions and links to plugin URIs.

## Steps to test

Check the data and links on the plugins list screen

## Screenshots/Videos

<img width="604" alt="image" src="https://github.com/bigbite/themer/assets/41474928/871e94a8-9f72-4c99-b1ba-79c414766abb">

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[BBT-96]: https://b5ecom.atlassian.net/browse/BBT-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ