### PR TITLE
[bbt-55] Collapse Menu Link Behaviour

### DIFF
--- a/src/editor/styles/base.scss
+++ b/src/editor/styles/base.scss
@@ -17,6 +17,13 @@
 	display: none;
 }
 
+/**
+* Fixes collapse button font size when editor is open
+*/
+#collapse-button {
+	font-size: 13px;
+}
+
 .theme-settings-page-wrapper {
 	margin: 0;
 }


### PR DESCRIPTION
## Description

Fixes [#55](https://github.com/bigbite/themer/issues/55) - the 'collapse menu' link was changing size when Themer was open.


## Change Log

- Added a CSS rule to ensure the link stays at the right size

## Steps to test

Just open up themer and check the 'collapse menu' link. The font size should remain at 13px

## Note

The 13px font size is not uniform with the rest of the menu. The problem itself occurs because the font is not set in the same way that the other links use, it inherits the body font size which is somewhat janky of wordpress imo. 
Rather than modify themer css too much, the most elegant way to fix this was to just add a new rule.

## Screenshots/Videos

http://bigbite.im/i/eKj6p8

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
