### PR TITLE
[BBT-62] Change visual preview to code view (fixes)

### DIFF
--- a/src/editor/components/CodeView.js
+++ b/src/editor/components/CodeView.js
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 /**
  * Renders code view component.
  *
@@ -7,16 +6,9 @@ import { __ } from '@wordpress/i18n';
  */
 const CodeView = ( { themeConfig } ) => {
 	return (
-		<>
-			<span className="themer--styles__item__title">
-				{ __( 'Settings', 'themer' ) }
-			</span>
-			<pre>{ JSON.stringify( themeConfig.settings, null, 2 ) }</pre>
-			<span className="themer--styles__item__title">
-				{ __( 'Styles', 'themer' ) }
-			</span>
-			<pre>{ JSON.stringify( themeConfig.styles, null, 2 ) }</pre>
-		</>
+		<pre>
+			<code>{ JSON.stringify( themeConfig, null, 2 ) }</code>
+		</pre>
 	);
 };
 

--- a/src/editor/components/ThemerComponent.js
+++ b/src/editor/components/ThemerComponent.js
@@ -358,11 +358,9 @@ const ThemerComponent = () => {
 											<StylesPanel />
 										</div>
 										<div className="themer-code-view-container">
-											<div>
-												<CodeView
-													themeConfig={ themeConfig }
-												/>
-											</div>
+											<CodeView
+												themeConfig={ themeConfig }
+											/>
 										</div>
 									</div>
 								</div>

--- a/src/editor/styles/codeView.scss
+++ b/src/editor/styles/codeView.scss
@@ -1,6 +1,6 @@
 .themer-code-view-container {
     border: #ccc 1px solid;
-    padding: 20px;
     max-height: var(--themer-preview-height);
-    overflow-y: auto;
+    overflow: auto;
+    margin-bottom: 20px;
 }


### PR DESCRIPTION
## Description

Fixes #62 - Addresses feedback given here https://github.com/bigbite/themer/issues/62#issuecomment-2192292399

## Change Log

- Render whole themeConfig object rather than just styles and settings
- Wraps code view in `<pre>` and `<code>` tags
- Fixes CSS issue where code view section was too long

## Screenshots/Videos

![image](https://github.com/bigbite/themer/assets/62053290/8b24cbad-83da-4736-85aa-e7e7e0384486)

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
