### PR TITLE
[bbt-70] Hotfix - code view background color

### DIFF
--- a/src/editor/styles/codeView.scss
+++ b/src/editor/styles/codeView.scss
@@ -3,4 +3,8 @@
     max-height: var(--themer-preview-height);
     overflow: auto;
     margin-bottom: 20px;
+
+    code {
+        background: unset;
+    }
 }


### PR DESCRIPTION
## Description

Fixes an issue the came up in #70 

Since adding pre and code tags to the code view, the code view has a default background color applied to the text. This PR removes that.


## Change Log
- Unset background color on the code view


## Steps to test

Just a small css change so just make sure there is no background color on the code view

## Screenshots/Videos
no
![Screenshot on 2024-06-27 at 14-24-01](https://github.com/bigbite/themer/assets/33436145/e5d6e494-189c-4006-9869-f36e793dd496)

yes
![Screenshot on 2024-06-27 at 14-22-46](https://github.com/bigbite/themer/assets/33436145/f7fcdb1f-2558-4f91-a556-67f5dd56624d)

