### PR TITLE
[77] Move no theme.json file found error message so it displays correctly.

### DIFF
--- a/src/editor/components/ThemerComponent.js
+++ b/src/editor/components/ThemerComponent.js
@@ -187,6 +187,16 @@ const ThemerComponent = () => {
 		);
 	};
 
+	if ( validThemeJson?.error_type === 'error' ) {
+		return (
+			<ThemerNotice
+				status={ validThemeJson?.error_type }
+				message={ validThemeJson?.message }
+				isDismissible={ false }
+			/>
+		);
+	}
+
 	if ( ! themeConfig || ! previewCss || ! globalStylesId ) {
 		return (
 			<>
@@ -216,73 +226,62 @@ const ThemerComponent = () => {
 						setUserConfig,
 					} }
 				>
-					<ThemerNotice
-						status={ validThemeJson?.error_type }
-						message={ validThemeJson?.message }
-						isDismissible={ false }
-					/>
-					{ validThemeJson === true && (
-						<>
-							<div className="themer-topbar">
-								<Button
-									isSecondary
-									onClick={ () => reset() }
-									text="Reset"
-									disabled={ ! hasUnsavedChanges }
-								/>
-								<Button
-									isPrimary
-									onClick={ () => save() }
-									text="Save"
-									disabled={ ! hasUnsavedChanges }
-								/>
-								<MoreMenuDropdown>
-									{ () => (
-										<MenuGroup
-											label={ __( 'Tools', 'themer' ) }
-											className="themer-more-menu"
-										>
-											<ButtonExport />
-											<MenuItem
-												role="menuitem"
-												icon={ trash }
-												info={ __(
-													'Resets all customisations to your initial theme.json configuration.',
-													'themer'
-												) }
-												onClick={ () =>
-													clearAllCustomisations()
-												}
-												isDestructive
-											>
-												{ __(
-													'Clear all customisations',
-													'themer'
-												) }
-											</MenuItem>
-										</MenuGroup>
-									) }
-								</MoreMenuDropdown>
+					<div className="themer-topbar">
+						<Button
+							isSecondary
+							onClick={ () => reset() }
+							text="Reset"
+							disabled={ ! hasUnsavedChanges }
+						/>
+						<Button
+							isPrimary
+							onClick={ () => save() }
+							text="Save"
+							disabled={ ! hasUnsavedChanges }
+						/>
+						<MoreMenuDropdown>
+							{ () => (
+								<MenuGroup
+									label={ __( 'Tools', 'themer' ) }
+									className="themer-more-menu"
+								>
+									<ButtonExport />
+									<MenuItem
+										role="menuitem"
+										icon={ trash }
+										info={ __(
+											'Resets all customisations to your initial theme.json configuration.',
+											'themer'
+										) }
+										onClick={ () =>
+											clearAllCustomisations()
+										}
+										isDestructive
+									>
+										{ __(
+											'Clear all customisations',
+											'themer'
+										) }
+									</MenuItem>
+								</MenuGroup>
+							) }
+						</MoreMenuDropdown>
+					</div>
+					<NavigatorProvider initialPath="/">
+						<div className="themer-body">
+							<div className="themer-nav-container">
+								<Nav />
 							</div>
-							<NavigatorProvider initialPath="/">
-								<div className="themer-body">
-									<div className="themer-nav-container">
-										<Nav />
-									</div>
-									<div className="themer-content-container">
-										<div className="themer-styles-container">
-											<StylesPanel />
-										</div>
-										<div className="themer-code-view-container">
-											<CodeView
-												themeConfig={ themeConfig }
-											/>
-										</div>
-									</div>
+							<div className="themer-content-container">
+								<div className="themer-styles-container">
+									<StylesPanel />
 								</div>
-							</NavigatorProvider>
-						</>
-					) }
+								<div className="themer-code-view-container">
+									<CodeView themeConfig={ themeConfig } />
+								</div>
+							</div>
+						</div>
+					</NavigatorProvider>
 				</StylesContext.Provider>
 			</EditorContext.Provider>
 		</>


### PR DESCRIPTION
[77](https://github.com/bigbite/themer/issues/77) - This PR moves the `ThemerNotice` component into a position so that it shows when no theme.json file is found.


## Change Log

- Adds a new if statement to check for the theme.json file
- Removes checks from the last return statement as these are done further up now.

## Steps to test

Go to the style editor and check themer works
Remove or rename theme.json in the theme folder
Refresh the page
The error `cannot read the file "theme.json" ` should show


## Screenshots/Videos

http://bigbite.im/v/vg2HSM

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
