### PR TITLE
[83] Contextualise code view based on current navigator location

### DIFF
--- a/src/editor/components/CodeView.js
+++ b/src/editor/components/CodeView.js
@@ -1,3 +1,6 @@
+import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
+
 /**
  * Renders code view component.
  *
@@ -5,9 +8,70 @@
  * @param {Object} props.themeConfig Current theme configuration
  */
 const CodeView = ( { themeConfig } ) => {
+	const { location } = useNavigator();
+
+	/**
+	 * Get the code section within the theme config which relates to
+	 * the current navigator location.
+	 *
+	 * e.g. `/blocks/core%2Fparagraph` -> `blocks.['core/paragraph']`
+	 * e.g. `/elements/button/:hover` -> `elements.button.[':hover']`
+	 * e.g. `/blocks/core%2Fcolumn/caption/:focus` -> `blocks.['core/column'].elements.caption.[':focus']`
+	 */
+	const code = useMemo( () => {
+		/**
+		 * If the current location is the root path, return the entire
+		 * styles object, omitting the blocks and elements keys.
+		 */
+		if ( location.path === '/' ) {
+			const { blocks, elements, ...rest } = themeConfig.styles;
+			return rest;
+		}
+
+		/**
+		 * Remove the leading slash from the path so we don't end up with
+		 * an empty string as the first part of the pathParts array.
+		 */
+		const path = location.path.startsWith( '/' )
+			? location.path.slice( 1 )
+			: location.path;
+
+		/**
+		 * Split the path into parts and replace any encoded slashes with
+		 * regular slashes, as these are used in block names.
+		 */
+		const pathParts = path.split( '/' ).map( ( part ) => {
+			return part.replace( /%2F/g, '/' );
+		} );
+
+		/**
+		 * Elements nested under blocks are stored in the styles object
+		 * as `blocks.blockName.elements.elementName`. This code ensures
+		 * that the correct path is used in these cases.
+		 *
+		 * e.g. `/blocks/core%2Fbutton/link` -> `blocks.['core/button'].elements.link`
+		 */
+		if ( pathParts[ 0 ] === 'blocks' && pathParts.length >= 3 ) {
+			pathParts.splice( 2, 0, 'elements' );
+		}
+
+		/**
+		 * Traverse the theme config object to find the code section
+		 * that relates to the current navigator location.
+		 */
+		const foundCode = pathParts.reduce( ( acc, part ) => {
+			if ( acc ) {
+				return acc[ part ];
+			}
+			return acc;
+		}, themeConfig.styles );
+
+		return foundCode;
+	}, [ themeConfig, location ] );
+
 	return (
 		<pre>
-			<code>{ JSON.stringify( themeConfig, null, 2 ) }</code>
+			<code>{ JSON.stringify( code, null, 2 ) }</code>
 		</pre>
 	);
 };


### PR DESCRIPTION
## Description

This PR updates the code preview to show only the styles currently being edited, rather than the entire theme config.

The router context is used to allow the code preview to change based on the current navigator location. In other words, when you click a block or element, you will only see the styles related to that item in the code preview area.

This makes it clearer which style changes are being applied. This change only impacts the code preview, the theme.json export is left untouched and will contain all data.

Related #83

## Change Log

- Contextualises code preview based on navigator location

## Steps to test

- Visit the themer settings page
- Notice the code preview should only show existing site styles
- Navigate to different elements - blocks, elements, elements nested inside blocks, pseudo-states, etc.
- Notice the preview should update based on the location you navigate to
- Check the preview reflects any changes in real time as you make them

## Screenshots/Videos

https://github.com/user-attachments/assets/1790578e-1d90-4077-bf36-d09ca522d167

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
