### PR TITLE
[89] Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,11 @@
 # themer
 
-## Installing
+# Installation
 
-When installing to your site, add the following to you `composer.json` file. This will ensure that installation will use the build version of the package and allow it to be loaded using composer in the preferred path.
+## Prerequisites
 
-```json
-{
-	"repositories": [
-		{
-			"type": "vcs",
-			"url": "git@github.com:@big-bite/themer.git"
-		}
-	],
-	"require": {
-		"@big-bite/themer": "dev-main-built"
-	},
-	"extra": {
-		"installer-paths": {
-			"plugins/{$name}/": [ "type:wordpress-plugin" ]
-		}
-	}
-}
-```
+-   **WordPress:** 6.2
+-   **PHP:** 8.0
 
 ## Local Development or Manual Install
 
@@ -37,24 +21,23 @@ Install JS packages.
 npm install
 ```
 
-Build all assets
-
-```
-npm run build:prod
-```
-
 Install PHP packages and create autoloader for the plugin.
 
 ```
 composer update
 ```
 
-# Installation
+Build all assets
 
-## Prerequisites
+```
+npm run build:prod
+```
 
--   **WordPress:** 6.2
--   **PHP:** 8.0
+Or run in watch mode
+
+```
+npm run watch:dev
+```
 
 # Features
 


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->
![Screenshot on 2024-08-14 at 11-58-08](https://github.com/user-attachments/assets/e14437f8-6512-423b-8e77-35a12e5dc26d)

## Description
This is just a small change to the readme file. It updates the install instructions outlined in #89 
<!---
Please ensure `{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. GitHub issues can also be used in replacement and should use keyword links: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Example format:
Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aid with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->

## Change Log

<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->

- Updated readme file

## Steps to test

<!--- Please describe how you tested your changes and how a reviewer can do the same. --->
Just a quick proof read will be sufficient

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
