### PR TITLE
[93] Fixes colors breaking after value is cleared and saved

### DIFF
--- a/src/editor/components/ThemerComponent.js
+++ b/src/editor/components/ThemerComponent.js
@@ -25,6 +25,7 @@ import EditorContext from '../context/EditorContext';
 import StylesContext from '../context/StylesContext';
 
 import fetchSchema from '../../utils/schema-helpers';
+import { removeEmptyValues } from '../../utils/block-helpers';
 import { getDefaultPreview } from '../../utils/blockPreviews';
 
 /**
@@ -38,6 +39,7 @@ const ThemerComponent = () => {
 	const [ validThemeJson, setValidThemeJson ] = useState();
 
 	const setUserConfig = ( config ) => {
+		config = removeEmptyValues( config );
 		dispatch( 'core' ).editEntityRecord(
 			'root',
 			'globalStyles',
@@ -81,7 +83,9 @@ const ThemerComponent = () => {
 		if ( isEmpty( userConfig ) ) {
 			return baseConfig;
 		}
+
 		const merged = mergeWith( {}, baseConfig, userConfig );
+
 		return merged;
 	}, [ userConfig, baseConfig ] );
 

--- a/src/utils/block-helpers.js
+++ b/src/utils/block-helpers.js
@@ -330,3 +330,57 @@ export const varToSpacing = ( spacingValue, themeSpacingSizes ) => {
 
 	return getCustomValueFromPreset( valueInCorrectFormat, themeSpacingSizes );
 };
+
+/**
+ * Recursively removes empty values from an object or array.
+ *
+ * This function traverses the input object or array and removes any values that are:
+ * - null
+ * - undefined
+ * - empty strings
+ * - empty arrays
+ * - empty objects
+ *
+ * If an array becomes empty after its elements are filtered, it is removed (i.e., replaced with null).
+ * If an object becomes empty after its properties are filtered, it is removed (i.e., replaced with null).
+ *
+ * @param {Object|Array} obj - The input object or array to be filtered.
+ * @return {Object|Array|null} - The filtered object or array, or null if it becomes empty.
+ */
+export const removeEmptyValues = ( obj ) => {
+	if ( Array.isArray( obj ) ) {
+		const filteredArray = obj
+			.map( ( item ) => removeEmptyValues( item ) )
+			.filter(
+				( item ) =>
+					item !== null &&
+					item !== undefined &&
+					item !== '' &&
+					! ( Array.isArray( item ) && item.length === 0 ) &&
+					! (
+						typeof item === 'object' &&
+						Object.keys( item ).length === 0
+					)
+			);
+		return filteredArray.length > 0 ? filteredArray : null;
+	} else if ( typeof obj === 'object' && obj !== null ) {
+		const filteredObject = Object.keys( obj ).reduce( ( acc, key ) => {
+			const value = removeEmptyValues( obj[ key ] );
+			if (
+				value !== null &&
+				value !== undefined &&
+				value !== '' &&
+				! ( Array.isArray( value ) && value.length === 0 ) &&
+				! (
+					typeof value === 'object' &&
+					Object.keys( value ).length === 0
+				)
+			) {
+				acc[ key ] = value;
+			}
+			return acc;
+		}, {} );
+		return Object.keys( filteredObject ).length > 0 ? filteredObject : null;
+	}
+	return obj;
+};


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description

Fixes #93 - addresses feedback given [Here](https://github.com/bigbite/themer/issues/93#issuecomment-2291323544)

### Note
Although the bug has been fixed and the user can no longer get into a situation where they can't select a colour, the colour picker still can't be cleared if a default value exists. I believe fixing this will require a rethink of how we are handling data. A proposal for handling data more efficiently can be found HERE(soon)

<!---
Please ensure `{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. GitHub issues can also be used in replacement and should use keyword links: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Example format:
Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aid with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->

## Change Log

<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->

- Adds a new utility function - `removeEmptyValues`
- Removes any empty values before `setUserConfig` is dispatched

## Steps to test

<!--- Please describe how you tested your changes and how a reviewer can do the same. --->

You can follow http://bigbite.im/v/WSCUlJ to test however, the problem will not be apparent if any default data exists. I was only able to recreate this issue on `blocks`. See comments in the description for further info

- Go to a block, set one of the colours and save it
- Now clear the colour picker and see the value should be completely removed from the code view
- Save the empty state
- Now select a colour again and everything should work as expected


## Screenshots/Videos

<!--- Please include a video demonstrating how to use new features. This may include setup. Nothing has to be perfect. --->

https://github.com/user-attachments/assets/0fd1c5d1-eb93-4315-843b-d317c7903a54


## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
