### PR TITLE
[93] Ensure undefined or invalid colours fall back to an empty string

### DIFF
--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -28,7 +28,7 @@ const Color = ( { selector } ) => {
 		config = set(
 			config,
 			[ selector, key ].join( '.' ),
-			hexToVar( newValue, themePalette )
+			hexToVar( newValue, themePalette ) ?? ''
 		);
 		setUserConfig( config );
 	};


### PR DESCRIPTION
## Description

This change fixes #93 by preventing `undefined` being set as the colour value when the "Clear" button is pressed in the UI.

It also allows for overwriting of inherited/existing colour values within theme.json, as it forcibly sets the value to an empty string when cleared. In order to get the original value back, you can choose the 'clear all customisations' option from the more menu.

## Steps to test

- Install themer and twentytwentyfour theme
- Navigate to 'Appearance > Styles Editor'
- Notice that the site should have colours set by default for background and text
- Clear the colours
- Notice they update to empty strings and the colour is no longer applied on the frontend

## Screenshots/Videos

https://github.com/user-attachments/assets/a0454e1e-ea90-4533-a270-b51a1e738fb4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
