### PR TITLE
[BBT-96] Re-order block list 

### DIFF
--- a/src/editor/components/NavBlockList.js
+++ b/src/editor/components/NavBlockList.js
@@ -22,10 +22,15 @@ const NavBlockList = () => {
 	// get styles for all blocks
 	const themeBlockStyles = getThemeOption( `styles.blocks`, themeConfig );
 
+	// sort the blocks by title
+	const orderedSchema = schemaBlocks.sort( ( a, b ) =>
+		a.title.localeCompare( b.title )
+	);
+
 	return (
 		<section>
 			<ul className="themer-nav-list">
-				{ schemaBlocks.map( ( block ) => {
+				{ orderedSchema.map( ( block ) => {
 					// get all styles for this block
 					const blockStyles = themeBlockStyles[ block.name ] || {};
 

--- a/src/editor/components/NavElementList.js
+++ b/src/editor/components/NavElementList.js
@@ -22,6 +22,11 @@ const NavElementList = ( { selector, route } ) => {
 	// get all valid elements from the schema
 	const schemaElements = getElementsFromSchema( schema );
 
+	// sort the elements by name
+	const orderedSchema = schemaElements.sort( ( a, b ) =>
+		a.name.localeCompare( b.name )
+	);
+
 	// get styles for all elements at this selector
 	const themeElementStyles =
 		getThemeOption( `styles.${ selector }`, themeConfig ) || {};
@@ -29,7 +34,7 @@ const NavElementList = ( { selector, route } ) => {
 	return (
 		<section>
 			<ul className="themer-nav-list">
-				{ schemaElements.map( ( element ) => {
+				{ orderedSchema.map( ( element ) => {
 					// get all styles for this element
 					const elementStyles =
 						themeElementStyles[ element.name ] || {};


### PR DESCRIPTION
**reviewer note, i've added the base of release/1.0.0 for now, however this can be changed to the correct one if required**

#96 Re order of block list in Nav

## Description

This adds functions in to re-order the objects that display the Blocks and Elements in the Themer Nav.

Blocks are ordered by title and Elements have been ordered by name. Element reordering wasn't in the original ticket but can be easily removed if required.

## Change Log

- Adds in functions to order Blocks and Elements in respective nav components

## Steps to test

In the Nav in Themer, blocks such as core/block which has the title 'Pattern' will now be alphabetically correct for Pattern rather than Block.

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
