### PR TITLE
[BBT-105] Display notification when related background and foreground colours fail accessible colour contrast ratios

### DIFF
--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -1,6 +1,6 @@
 import { set } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { useContext } from '@wordpress/element';
+import { useContext, useState, useEffect } from '@wordpress/element';
 import { ColorPalette } from '@wordpress/components';
 import { ContrastChecker } from '@wordpress/block-editor';
 
@@ -35,6 +35,44 @@ const Color = ( { selector } ) => {
 		setUserConfig( config );
 	};
 
+	/**
+	 * Define mouse state and related functions
+	 */
+	const [ isMouseDown, setIsMouseDown ] = useState( false );
+	const handleMouseDown = () => setIsMouseDown( true );
+	const handleMouseUp = () => setIsMouseDown( false );
+
+	/**
+	 * Define colour variables, used to avoid jumping colour picker when ContrastChecker display toggles
+	 */
+	const [ textColour, setTextColour ] = useState( colorStyles.text );
+	const [ backgroundColour, setBackgroundColour ] = useState(
+		colorStyles.background
+	);
+
+	/**
+	 * When the values are changed, ensure the mouse buttons have been released before updating
+	 */
+	useEffect( () => {
+		if ( ! isMouseDown ) {
+			setTextColour( colorStyles.text );
+			setBackgroundColour( colorStyles.background );
+		}
+	}, [ isMouseDown, colorStyles.text, colorStyles.background ] );
+
+	/**
+	 * Add and remove the mouse event listeners
+	 */
+	useEffect( () => {
+		window.addEventListener( 'mousedown', handleMouseDown );
+		window.addEventListener( 'mouseup', handleMouseUp );
+
+		return () => {
+			window.removeEventListener( 'mousedown', handleMouseDown );
+			window.removeEventListener( 'mouseup', handleMouseUp );
+		};
+	}, [] );
+
 	const colorPalettes = [ 'background', 'text' ].map( ( key ) => (
 		<div key={ key } className="themer--styles__item__column">
 			<span className="themer--styles__item__label">{ key }</span>
@@ -53,11 +91,8 @@ const Color = ( { selector } ) => {
 				{ __( 'Color', 'themer' ) }
 			</span>
 			<ContrastChecker
-				textColor={ varToHex( colorStyles.text, themePalette ) }
-				backgroundColor={ varToHex(
-					colorStyles.background,
-					themePalette
-				) }
+				textColor={ varToHex( textColour, themePalette ) }
+				backgroundColor={ varToHex( backgroundColour, themePalette ) }
 			/>
 			<div className="themer--styles__item__columns themer--styles__item__columns--2">
 				{ colorPalettes }

--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -1,6 +1,6 @@
 import { set, debounce } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { useContext, useState, useEffect } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { ColorPalette } from '@wordpress/components';
 import { ContrastChecker } from '@wordpress/block-editor';
 
@@ -26,20 +26,12 @@ const Color = ( { selector } ) => {
 	);
 
 	/**
-	 * Define colour variables, used to avoid jumping colour picker when ContrastChecker display toggles
-	 */
-	const [ textColour, setTextColour ] = useState( colorStyles.text );
-	const [ backgroundColour, setBackgroundColour ] = useState(
-		colorStyles.background
-	);
-
-	/**
 	 * Function to handle the colour palette changes
 	 *
 	 * @param {string} newValue The value of the setting
 	 * @param {string} key      The key of the setting
 	 */
-	const onChange = ( newValue, key ) => {
+	const onChange = debounce( ( newValue, key ) => {
 		let config = structuredClone( userConfig );
 		config = set(
 			config,
@@ -47,26 +39,7 @@ const Color = ( { selector } ) => {
 			hexToVar( newValue, themePalette ) ?? ''
 		);
 		setUserConfig( config );
-	};
-
-	/**
-	 * Function to debounce the assignment of colours
-	 * This approach addresses an interaction issue with custom colour palettes
-	 */
-	const debouncedUpdateColors = debounce( () => {
-		setTextColour( colorStyles.text );
-		setBackgroundColour( colorStyles.background );
-	}, 150 );
-
-	/**
-	 * useEffect when colours are updated
-	 */
-	useEffect( () => {
-		debouncedUpdateColors();
-		return () => {
-			debouncedUpdateColors.cancel();
-		};
-	}, [ colorStyles.text, colorStyles.background, debouncedUpdateColors ] );
+	}, 50 );
 
 	const colorPalettes = [ 'background', 'text' ].map( ( key ) => (
 		<div key={ key } className="themer--styles__item__column">
@@ -86,8 +59,11 @@ const Color = ( { selector } ) => {
 				{ __( 'Color', 'themer' ) }
 			</span>
 			<ContrastChecker
-				textColor={ varToHex( textColour, themePalette ) }
-				backgroundColor={ varToHex( backgroundColour, themePalette ) }
+				textColor={ varToHex( colorStyles.text, themePalette ) }
+				backgroundColor={ varToHex(
+					colorStyles.background,
+					themePalette
+				) }
 			/>
 			<div className="themer--styles__item__columns themer--styles__item__columns--2">
 				{ colorPalettes }

--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -2,6 +2,7 @@ import { set } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import { ColorPalette } from '@wordpress/components';
+import { ContrastChecker } from '@wordpress/block-editor';
 
 import { varToHex, hexToVar } from '../../utils/block-helpers';
 import getThemeOption from '../../utils/get-theme-option';
@@ -51,6 +52,13 @@ const Color = ( { selector } ) => {
 			<span className="themer--styles__item__title">
 				{ __( 'Color', 'themer' ) }
 			</span>
+			<ContrastChecker
+				textColor={ varToHex( colorStyles.text, themePalette ) }
+				backgroundColor={ varToHex(
+					colorStyles.background,
+					themePalette
+				) }
+			/>
 			<div className="themer--styles__item__columns themer--styles__item__columns--2">
 				{ colorPalettes }
 				<Gradient selector={ `${ selector }.gradient` } />

--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -58,8 +58,6 @@ const Color = ( { selector } ) => {
 			setTextColor( colorStyles.text );
 			setBackgroundColor( colorStyles.background );
 		}, 150 );
-
-		//
 		debouncedUpdateColors();
 
 		return () => {

--- a/src/editor/components/StylesColor.js
+++ b/src/editor/components/StylesColor.js
@@ -1,6 +1,6 @@
 import { set } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { useContext, useState, useEffect } from '@wordpress/element';
+import { useContext, useState, useEffect, useRef } from '@wordpress/element';
 import { ColorPalette } from '@wordpress/components';
 import { ContrastChecker } from '@wordpress/block-editor';
 
@@ -17,6 +17,7 @@ import Gradient from './StylesGradient';
  * @param {string} props.selector Property target selector
  */
 const Color = ( { selector } ) => {
+	const containerRef = useRef( null );
 	const { userConfig, themeConfig } = useContext( EditorContext );
 	const { setUserConfig } = useContext( StylesContext );
 	const colorStyles = getThemeOption( selector, themeConfig ) || {};
@@ -64,12 +65,18 @@ const Color = ( { selector } ) => {
 	 * Add and remove the mouse event listeners
 	 */
 	useEffect( () => {
-		window.addEventListener( 'mousedown', handleMouseDown );
-		window.addEventListener( 'mouseup', handleMouseUp );
+		const container = containerRef.current;
+
+		if ( container ) {
+			container.addEventListener( 'mousedown', handleMouseDown );
+			container.addEventListener( 'mouseup', handleMouseUp );
+		}
 
 		return () => {
-			window.removeEventListener( 'mousedown', handleMouseDown );
-			window.removeEventListener( 'mouseup', handleMouseUp );
+			if ( container ) {
+				container.removeEventListener( 'mousedown', handleMouseDown );
+				container.removeEventListener( 'mouseup', handleMouseUp );
+			}
 		};
 	}, [] );
 
@@ -77,8 +84,8 @@ const Color = ( { selector } ) => {
 		<div key={ key } className="themer--styles__item__column">
 			<span className="themer--styles__item__label">{ key }</span>
 			<ColorPalette
-				label={ __( 'Color', 'themer' ) }
 				colors={ themePalette }
+				label={ __( 'Color', 'themer' ) }
 				onChange={ ( value ) => onChange( value, key ) }
 				value={ varToHex( colorStyles[ key ], themePalette ) }
 			/>
@@ -94,7 +101,10 @@ const Color = ( { selector } ) => {
 				textColor={ varToHex( textColour, themePalette ) }
 				backgroundColor={ varToHex( backgroundColour, themePalette ) }
 			/>
-			<div className="themer--styles__item__columns themer--styles__item__columns--2">
+			<div
+				ref={ containerRef }
+				className="themer--styles__item__columns themer--styles__item__columns--2"
+			>
 				{ colorPalettes }
 				<Gradient selector={ `${ selector }.gradient` } />
 			</div>


### PR DESCRIPTION
## Description

[BBT-105](https://github.com/bigbite/themer/issues/105) - This PR adds a [contrast checker](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/contrast-checker/README.md) to `text` and `background` colour pickers. When the selected colours do not have a sufficient contrast ratio, which may cause accessibility issues, a notification is displayed to inform the user.

The `ContrastChecker` component has been positioned inbetween the item title and palette selectors so it does not interfere with the grid layout of those components (when placed inside the columns container, the layout would shift pushing the columns out of place which could be confusing). I did experiment with including the `ContrastChecker` output at both the top and bottom of the container however it felt excessive and could also be confusing.

**NOTE** - This change only considers the `text` and `background` colours, it does not take into consideration any selected `gradient` colours at this time.

## Change Log

- `src/editor/components/StylesColor.js` - Imported, and used, the `ContrastChecker` to compare the text and background colours

## Steps to test

- Select a `block` or `element` that has the `text` and `background` colour options, such as `Elements > Button`
- Select a `text` colour from the available palette
- Select a _contrasting_ colour for the `background` from the palette
- Notice not warning is displayed
- Select the **same** colour for the `background` that is assigned to `text`
- Notice a contrast warning is now displayed

## Screenshots/Videos

[Demo showing the colour contrast notification when selecting colours](http://bigbite.im/v/wZaeqk)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
