### PR TITLE
Add block template manager

### DIFF
--- a/src/editor/components/ButtonTemplateManager.js
+++ b/src/editor/components/ButtonTemplateManager.js
@@ -5,11 +5,8 @@ import TemplateManagerModal from './TemplateManagerModal';
 
 /**
  * Renders the button to export theme.json
- *
- * @param {Object} props
- * @param {Function} props.onClose Callback to close the modal
  */
-const ButtonTemplateManager = ( { onClose } ) => {
+const ButtonTemplateManager = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
 	return (

--- a/src/editor/components/ButtonTemplateManager.js
+++ b/src/editor/components/ButtonTemplateManager.js
@@ -13,10 +13,7 @@ const ButtonTemplateManager = () => {
 		<>
 			<MenuItem
 				role="menuitem"
-				onClick={ () => {
-					// onClose();
-					setIsModalOpen( true );
-				} }
+				onClick={ () => setIsModalOpen( true ) }
 				info={ __( 'Manage block templates.', 'themer' ) }
 			>
 				{ __( 'Block Templates', 'themer' ) }

--- a/src/editor/components/ButtonTemplateManager.js
+++ b/src/editor/components/ButtonTemplateManager.js
@@ -1,0 +1,32 @@
+import { __ } from '@wordpress/i18n';
+import { MenuItem } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import TemplateManagerModal from './TemplateManagerModal';
+
+/**
+ * Renders the button to export theme.json
+ *
+ * @param {Object} props
+ * @param {Function} props.onClose Callback to close the modal
+ */
+const ButtonTemplateManager = ( { onClose } ) => {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	return (
+		<>
+			<MenuItem
+				role="menuitem"
+				onClick={ () => {
+					// onClose();
+					setIsModalOpen( true );
+				} }
+				info={ __( 'Manage block templates.', 'themer' ) }
+			>
+				{ __( 'Block Templates', 'themer' ) }
+			</MenuItem>
+			<TemplateManagerModal isModalOpen={ isModalOpen } />
+		</>
+	);
+};
+
+export default ButtonTemplateManager;

--- a/src/editor/components/ComponentSettings/TypographySettings/FontFaceSrc.js
+++ b/src/editor/components/ComponentSettings/TypographySettings/FontFaceSrc.js
@@ -14,7 +14,6 @@ import StylesContext from '../../../context/StylesContext';
  * @param {string} props.selector      Property target selector
  * @param {number} props.familyIndex   Index of the font family
  * @param {number} props.fontFaceIndex Index of the font face
- *
  */
 const FontFaceSrc = ( { selector, familyIndex, fontFaceIndex } ) => {
 	const { userConfig, themeConfig } = useContext( EditorContext );

--- a/src/editor/components/TemplateManagerModal.js
+++ b/src/editor/components/TemplateManagerModal.js
@@ -1,0 +1,86 @@
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Modal,
+	__experimentalHStack as HStack,
+	ExternalLink,
+} from '@wordpress/components';
+import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+
+import saveTemplate from '../../utils/save-template';
+import { download, backup } from '@wordpress/icons';
+
+/**
+ * Renders the button to export theme.json
+ *
+ * @param {Object}  props
+ * @param {boolean} props.isOpen Whether the modal is open
+ */
+const TemplateManagerModal = ( { isOpen, setIsOpen } ) => {
+	const { deleteEntityRecord } = useDispatch( coreStore );
+
+	const { records: templates } = useEntityRecords(
+		'postType',
+		'wp_template',
+		{
+			per_page: 100,
+		}
+	);
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			focusOnMount
+			title={ __( 'Block Templates', 'themer' ) }
+			onRequestClose={ () => setIsOpen( false ) }
+		>
+			<table>
+				{ templates.map( ( template ) => {
+					const isCustomised =
+						template.has_theme_file && template.source === 'custom';
+					const editUrl = `site-editor.php?postId=${ template.id }&postType=wp_template&canvas=edit`;
+					return (
+						<tr key={ template.id }>
+							<td>
+								<ExternalLink href={ editUrl }>
+									{ template.title.raw }
+								</ExternalLink>
+							</td>
+							<td>
+								{ isCustomised && (
+									<Button
+										icon={ backup }
+										isDestructive
+										onClick={ () =>
+											deleteEntityRecord(
+												'postType',
+												'wp_template',
+												template.id
+											)
+										}
+									>
+										{ __( 'Reset', 'themer' ) }
+									</Button>
+								) }
+							</td>
+							<td>
+								<Button
+									icon={ download }
+									onClick={ () => saveTemplate( template ) }
+								>
+									{ __( 'Export', 'themer' ) }
+								</Button>
+							</td>
+						</tr>
+					);
+				} ) }
+			</table>
+		</Modal>
+	);
+};
+
+export default TemplateManagerModal;

--- a/src/editor/components/TemplateManagerModal.js
+++ b/src/editor/components/TemplateManagerModal.js
@@ -1,10 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Modal,
-	__experimentalHStack as HStack,
-	ExternalLink,
-} from '@wordpress/components';
+import { Button, Modal, ExternalLink } from '@wordpress/components';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 
@@ -14,8 +9,9 @@ import { download, backup } from '@wordpress/icons';
 /**
  * Renders the button to export theme.json
  *
- * @param {Object}  props
- * @param {boolean} props.isOpen Whether the modal is open
+ * @param {Object}   props
+ * @param {boolean}  props.isOpen    Whether the modal is open
+ * @param {Function} props.setIsOpen Function to set the modal open state
  */
 const TemplateManagerModal = ( { isOpen, setIsOpen } ) => {
 	const { deleteEntityRecord } = useDispatch( coreStore );

--- a/src/editor/components/Topbar.js
+++ b/src/editor/components/Topbar.js
@@ -4,10 +4,12 @@ import {
 	MenuItem,
 	DropdownMenu,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { trash, moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 import ButtonExport from './ButtonExport';
+import TemplateManagerModal from './TemplateManagerModal';
 
 /**
  * Topbar component
@@ -21,6 +23,8 @@ import ButtonExport from './ButtonExport';
  * @param {Function} props.onClear Callback to clear all customisations
  */
 const Topbar = ( { isDirty, onReset, onSave, onClear } ) => {
+	const [ isTemplateManagerOpen, setIsTemplateManagerOpen ] =
+		useState( false );
 	return (
 		<div className="themer-topbar">
 			<Button
@@ -36,27 +40,51 @@ const Topbar = ( { isDirty, onReset, onSave, onClear } ) => {
 				disabled={ ! isDirty }
 			/>
 			<DropdownMenu icon={ moreVertical }>
-				{ () => (
-					<MenuGroup
-						label={ __( 'Tools', 'themer' ) }
-						className="themer-more-menu"
-					>
-						<ButtonExport />
-						<MenuItem
-							role="menuitem"
-							icon={ trash }
-							info={ __(
-								'Resets all customisations to your initial theme.json configuration.',
-								'themer'
-							) }
-							onClick={ onClear }
-							isDestructive
+				{ ( { onClose } ) => (
+					<>
+						<MenuGroup
+							label={ __( 'Tools', 'themer' ) }
+							className="themer-more-menu"
 						>
-							{ __( 'Clear all customisations', 'themer' ) }
-						</MenuItem>
-					</MenuGroup>
+							<ButtonExport />
+							<MenuItem
+								role="menuitem"
+								icon={ trash }
+								info={ __(
+									'Resets all customisations to your initial theme.json configuration.',
+									'themer'
+								) }
+								onClick={ onClear }
+								isDestructive
+							>
+								{ __( 'Clear all customisations', 'themer' ) }
+							</MenuItem>
+						</MenuGroup>
+						<MenuGroup
+							label={ __( 'Management', 'themer' ) }
+							className="themer-more-menu"
+						>
+							<MenuItem
+								role="menuitem"
+								onClick={ () => {
+									onClose();
+									setIsTemplateManagerOpen( true );
+								} }
+								info={ __(
+									'Manage block templates.',
+									'themer'
+								) }
+							>
+								{ __( 'Block Templates', 'themer' ) }
+							</MenuItem>
+						</MenuGroup>
+					</>
 				) }
 			</DropdownMenu>
+			<TemplateManagerModal
+				isOpen={ isTemplateManagerOpen }
+				setIsOpen={ setIsTemplateManagerOpen }
+			/>
 		</div>
 	);
 };

--- a/src/utils/save-template.js
+++ b/src/utils/save-template.js
@@ -1,0 +1,38 @@
+/**
+ * Save JSON blob to a file
+ *
+ * @param {Object} data block template
+ */
+const saveTemplate = async ( data ) => {
+	// Create PHP template header
+	const phpContent = `<?php
+/**
+ * Template Name: ${ data.title.raw }
+ */
+
+?>
+
+${ data.content.raw }`;
+
+	const blob = new Blob( [ phpContent ], {
+		type: 'application/x-httpd-php',
+	} );
+
+	const handle = await window.showSaveFilePicker( {
+		suggestedName: `${ data.slug }.php`,
+		types: [
+			{
+				description: 'PHP Files',
+				accept: {
+					'application/x-httpd-php': [ '.php' ],
+				},
+			},
+		],
+	} );
+	const stream = await handle.createWritable();
+
+	await stream.write( blob );
+	await stream.close();
+};
+
+export default saveTemplate;


### PR DESCRIPTION
## Description

This PR adds a block template manager view, where you can see a list of block templates, view them in the site editor, download their markup within `.php` files, and reset any database changes.

## Screenshots/Videos

https://github.com/user-attachments/assets/f84fd707-d4f6-49ff-a1f4-f5b19f72d466

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
