### PR TITLE
Fix issues with docs example not working

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,13 +30,14 @@ When installing to your site, add the following to you `composer.json` file. Thi
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "git@github.com:@bigbite/themer.git"
+			"url": "git@github.com:bigbite/themer.git"
 		}
 	],
 	"require": {
-		"@bigbite/themer": "^1.1.0"
+		"bigbite/themer": "^1.1.0"
 	},
 	"extra": {
+
 		"installer-paths": {
 			"plugins/{$name}/": [ "type:wordpress-plugin" ]
 		}
@@ -49,7 +50,7 @@ When installing to your site, add the following to you `composer.json` file. Thi
 Clone the repository into your `plugins` or `client-mu-plugins` directory.
 
 ```
-git clone git@github.com:@bigbite/themer.git && cd themer
+git clone git@github.com:bigbite/themer.git && cd themer
 ```
 
 Install JS packages.


### PR DESCRIPTION
<!---
Provide a general summary of your changes in the Title above - DO NOT USE BRANCH NAMES.
Titles should use Jira ticket references and title where applicable.
Example: [JIRA-0001] Outline additional requested information for Pull Requests.
--->

## Description

<!---
Please ensure `{[JIRA-0000](jira-url)} - {Description}` is used and that descriptions are as thorough as they can be. If there are related Jira tickets, please ensure those are included as above. GitHub issues can also be used in replacement and should use keyword links: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
Example format:
Fixes #123 and [JIRA-0011](https://bigbite.atlassian.net/browse/JIRA-0011) - We've found that additional information is required to aid with understanding on what is required from a PR, and that further clarification is needed for other areas. This PR adds some additional information to the PR template to ensure engineers are providing the correct information on Pull Requests and that the QA is getting the information they need for testing.
--->
This PR should fix issue raised in #118 

## Change Log

<!--- Change logs should include anything that has changed, added and fixed within your PR. Be as thorough as possible. --->
- updated docs composer example with the right install path
- updated manual install example with the right install path

## Steps to test

<!--- Please describe how you tested your changes and how a reviewer can do the same. --->

## Screenshots/Videos

<!--- Please include a video demonstrating how to use new features. This may include setup. Nothing has to be perfect. --->

## Checklist:

<!--- Have you performed all the below tasks? Put an `x` in all the boxes that apply: -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
