### PR TITLE
Improve block template export

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,10 +34,9 @@ When installing to your site, add the following to you `composer.json` file. Thi
 		}
 	],
 	"require": {
-		"bigbite/themer": "^1.2.0"
+		"bigbite/themer": "^1.2.1"
 	},
 	"extra": {
-
 		"installer-paths": {
 			"plugins/{$name}/": [ "type:wordpress-plugin" ]
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "@big-bite/themer",
-	"version": "1.2.0",
+	"name": "@bigbite/themer",
+	"version": "1.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@big-bite/themer",
-			"version": "1.2.0",
+			"name": "@bigbite/themer",
+			"version": "1.2.1",
 			"dependencies": {
 				"@wordpress/block-editor": "wp-6.4",
 				"@wordpress/block-library": "wp-6.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-	"name": "@big-bite/themer",
+	"name": "@bigbite/themer",
 	"description": "A plugin to help you style themes faster.",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"author": "Big Bite",
 	"engines": {
 		"node": ">=16.16.0",

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Themer
  * Description:       A plugin to help you style themes faster.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Requires at least: 6.4
  * Requires PHP:      8.0
  * Author:            Big Bite

--- a/src/editor/components/SavedPatternsModal.js
+++ b/src/editor/components/SavedPatternsModal.js
@@ -38,43 +38,46 @@ const SavedPatternsModal = ( { isOpen, setIsOpen } ) => {
 			onRequestClose={ () => setIsOpen( false ) }
 		>
 			<table>
-				{ patterns.map( ( pattern ) => {
-					const editUrl = `site-editor.php?postId=${ pattern.id }&postType=wp_block&canvas=edit`;
-					return (
-						<tr key={ pattern.id }>
-							<td>
-								<ExternalLink href={ editUrl }>
-									{ pattern.title.raw
-										? pattern.title.raw
-										: __( '(no title)', 'default' ) }
-								</ExternalLink>
-							</td>
-							<td>
-								<Button
-									icon={ trash }
-									isDestructive
-									onClick={ () =>
-										deleteEntityRecord(
-											'postType',
-											'wp_block',
-											pattern.id
-										)
-									}
-								>
-									{ __( 'Remove', 'themer' ) }
-								</Button>
-							</td>
-							<td>
-								<Button
-									icon={ download }
-									onClick={ () => savePhpFile( pattern ) }
-								>
-									{ __( 'Export', 'themer' ) }
-								</Button>
-							</td>
-						</tr>
-					);
-				} ) }
+				<tbody>
+					{ patterns.map( ( pattern ) => {
+						const editUrl = `site-editor.php?postId=${ pattern.id }&postType=wp_block&canvas=edit`;
+
+						return (
+							<tr key={ pattern.id }>
+								<td>
+									<ExternalLink href={ editUrl }>
+										{ pattern.title.raw
+											? pattern.title.raw
+											: __( '(no title)', 'default' ) }
+									</ExternalLink>
+								</td>
+								<td>
+									<Button
+										icon={ trash }
+										isDestructive
+										onClick={ () =>
+											deleteEntityRecord(
+												'postType',
+												'wp_block',
+												pattern.id
+											)
+										}
+									>
+										{ __( 'Remove', 'default' ) }
+									</Button>
+								</td>
+								<td>
+									<Button
+										icon={ download }
+										onClick={ () => savePhpFile( pattern ) }
+									>
+										{ __( 'Export', 'default' ) }
+									</Button>
+								</td>
+							</tr>
+						);
+					} ) }
+				</tbody>
 			</table>
 		</Modal>
 	);

--- a/src/editor/components/SavedPatternsModal.js
+++ b/src/editor/components/SavedPatternsModal.js
@@ -40,10 +40,20 @@ const SavedPatternsModal = ( { isOpen, setIsOpen } ) => {
 			<table>
 				<tbody>
 					{ patterns.map( ( pattern ) => {
+						const isSynced =
+							pattern.wp_pattern_sync_status !== 'unsynced';
+
 						const editUrl = `site-editor.php?postId=${ pattern.id }&postType=wp_block&canvas=edit`;
 
 						return (
 							<tr key={ pattern.id }>
+								<td>
+									{ isSynced && (
+										<span className="themer--tag">
+											{ __( 'Synced', 'themer' ) }
+										</span>
+									) }
+								</td>
 								<td>
 									<ExternalLink href={ editUrl }>
 										{ pattern.title.raw

--- a/src/editor/components/TemplateManagerModal.js
+++ b/src/editor/components/TemplateManagerModal.js
@@ -3,7 +3,7 @@ import { Button, Modal, ExternalLink } from '@wordpress/components';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 
-import { savePhpFile } from '../../utils/save-file';
+import { saveHtmlFile } from '../../utils/save-file';
 import { download, backup } from '@wordpress/icons';
 
 /**
@@ -66,7 +66,7 @@ const TemplateManagerModal = ( { isOpen, setIsOpen } ) => {
 							<td>
 								<Button
 									icon={ download }
-									onClick={ () => savePhpFile( template ) }
+									onClick={ () => saveHtmlFile( template ) }
 								>
 									{ __( 'Export', 'themer' ) }
 								</Button>

--- a/src/editor/components/TemplateManagerModal.js
+++ b/src/editor/components/TemplateManagerModal.js
@@ -35,45 +35,53 @@ const TemplateManagerModal = ( { isOpen, setIsOpen } ) => {
 			onRequestClose={ () => setIsOpen( false ) }
 		>
 			<table>
-				{ templates.map( ( template ) => {
-					const isCustomised =
-						template.has_theme_file && template.source === 'custom';
-					const editUrl = `site-editor.php?postId=${ template.id }&postType=wp_template&canvas=edit`;
-					return (
-						<tr key={ template.id }>
-							<td>
-								<ExternalLink href={ editUrl }>
-									{ template.title.raw }
-								</ExternalLink>
-							</td>
-							<td>
-								{ isCustomised && (
+				<tbody>
+					{ templates.map( ( template ) => {
+						const isCustom = template.source === 'custom';
+						const hasThemeFile = template.has_theme_file;
+
+						const editUrl = `site-editor.php?postId=${ template.id }&postType=wp_template&canvas=edit`;
+
+						return (
+							<tr key={ template.id }>
+								<td>
+									<ExternalLink href={ editUrl }>
+										{ template.title.raw }
+									</ExternalLink>
+								</td>
+								<td>
+									{ isCustom && (
+										<Button
+											icon={ backup }
+											isDestructive
+											onClick={ () =>
+												deleteEntityRecord(
+													'postType',
+													'wp_template',
+													template.id
+												)
+											}
+										>
+											{ hasThemeFile
+												? __( 'Reset', 'default' )
+												: __( 'Remove', 'default' ) }
+										</Button>
+									) }
+								</td>
+								<td>
 									<Button
-										icon={ backup }
-										isDestructive
+										icon={ download }
 										onClick={ () =>
-											deleteEntityRecord(
-												'postType',
-												'wp_template',
-												template.id
-											)
+											saveHtmlFile( template )
 										}
 									>
-										{ __( 'Reset', 'themer' ) }
+										{ __( 'Export', 'themer' ) }
 									</Button>
-								) }
-							</td>
-							<td>
-								<Button
-									icon={ download }
-									onClick={ () => saveHtmlFile( template ) }
-								>
-									{ __( 'Export', 'themer' ) }
-								</Button>
-							</td>
-						</tr>
-					);
-				} ) }
+								</td>
+							</tr>
+						);
+					} ) }
+				</tbody>
 			</table>
 		</Modal>
 	);

--- a/src/editor/styles/components/styles.scss
+++ b/src/editor/styles/components/styles.scss
@@ -158,3 +158,12 @@
 .themer--shadow-options button {
 	margin: 0 10px 10px 0;
 }
+
+.themer--tag {
+	border-radius: 3px;
+	background-color: #ccc;
+	text-transform: uppercase;
+	font-size: 0.6rem;
+	font-weight: 500;
+	padding: 2px 4px;
+}

--- a/src/utils/save-file.js
+++ b/src/utils/save-file.js
@@ -22,20 +22,17 @@ export const saveJsonFile = async ( filename, data ) => {
  * @param {Object} data block template
  */
 export const savePhpFile = async ( data ) => {
-	// Create PHP template header
-	let phpContent = '';
-	if ( 'wp_block' === data.type ) {
-		const name = data?.title?.raw || 'Untitled';
-		const description = data?.description?.raw || '';
-		const categories =
-			data.wp_pattern_category.length > 0
-				? data?._embedded[ 'wp:term' ][ 0 ]
-						.map( ( category ) => category.name )
-						.join( ', ' )
-				: '';
-		const slug = data?.slug || '';
+	const name = data?.title?.raw || 'Untitled';
+	const description = data?.description?.raw || '';
+	const categories =
+		data.wp_pattern_category.length > 0
+			? data?._embedded[ 'wp:term' ][ 0 ]
+					.map( ( category ) => category.name )
+					.join( ', ' )
+			: '';
+	const slug = data?.slug || '';
 
-		const patternContent = `<?php
+	const phpContent = `<?php
 /**
  * Template Name: ${ name }
  * Slug: ${ slug }
@@ -45,18 +42,6 @@ ${ categories && ` * Categories: ${ categories }` }
 ?>
 
 ${ data.content.raw }`;
-		phpContent = patternContent;
-	} else {
-		const templateContent = `<?php
-/**
- * Template Name: ${ data.title.raw }
- */
-
-?>
-
-${ data.content.raw }`;
-		phpContent = templateContent;
-	}
 
 	const blob = new Blob( [ phpContent ], {
 		type: 'application/x-httpd-php',
@@ -69,6 +54,35 @@ ${ data.content.raw }`;
 				description: 'PHP Files',
 				accept: {
 					'application/x-httpd-php': [ '.php' ],
+				},
+			},
+		],
+	} );
+	const stream = await handle.createWritable();
+
+	await stream.write( blob );
+	await stream.close();
+};
+
+/**
+ * Save JSON blob to a file as a PHP template or pattern depending on the type
+ *
+ * @param {Object} data block template
+ */
+export const saveHtmlFile = async ( data ) => {
+	const htmlContent = data.content.raw;
+
+	const blob = new Blob( [ htmlContent ], {
+		type: 'application/x-httpd-php',
+	} );
+
+	const handle = await window.showSaveFilePicker( {
+		suggestedName: `${ data.slug }.html`,
+		types: [
+			{
+				description: 'HTML Files',
+				accept: {
+					'application/x-httpd-html': [ '.html' ],
 				},
 			},
 		],

--- a/src/utils/save-file.js
+++ b/src/utils/save-file.js
@@ -5,7 +5,7 @@
  * @param {Object} data     theme.json data
  */
 export const saveJsonFile = async ( filename, data ) => {
-	const blob = new Blob( [ data ], { type: 'application/json' } ); // eslint-disable-line no-undef -- Blob available in browser environment
+	const blob = new Blob( [ data ], { type: 'application/json' } );
 
 	const handle = await window.showSaveFilePicker( {
 		suggestedName: filename,
@@ -17,7 +17,7 @@ export const saveJsonFile = async ( filename, data ) => {
 };
 
 /**
- * Save JSON blob to a file as a PHP template or pattern depending on the type
+ * Save a block pattern as a PHP file
  *
  * @param {Object} data block template
  */
@@ -65,7 +65,7 @@ ${ data.content.raw }`;
 };
 
 /**
- * Save JSON blob to a file as a PHP template or pattern depending on the type
+ * Save a block template to a HTML file
  *
  * @param {Object} data block template
  */


### PR DESCRIPTION
## Description

Block templates are now exported as `html` files, not `php`.

Although you can render blocks in `php` templates, this is not done in the way the initial version of this export feature had assumed (like how patterns work), and requires a large amount of surrounding boilerplate.

- The export option for block templates has been updated to generate a `html` file, which can either be directly used within a theme, or used as the basis for a more complex `php` template.

- An option has been added to delete a block template from the database if it was created entirely within the Site Editor and has no corresponding file in the theme.

- A visual indicator has been added so you can see if a pattern is 'synced' or not in the pattern manager modal